### PR TITLE
feat: 添加下载内存管理系统

### DIFF
--- a/ncmExtend/src/playlist/playlistDetail.js
+++ b/ncmExtend/src/playlist/playlistDetail.js
@@ -1,5 +1,5 @@
 import { weapiRequest } from "../utils/request"
-import { songsDownUpLoad } from "./SongsDownUpLoad"
+import { songsDownUpLoad } from "./songsDownUpLoad"
 import { sortSongs } from "./sortSongs"
 import { getAlbumTextInSongDetail, getArtistTextInSongDetail, escapeHTML, duringTimeDesc } from "../utils/descHelper"
 import { songItemAddToFormat } from "../utils/common"

--- a/ncmExtend/src/utils/downloadCleanupManager.js
+++ b/ncmExtend/src/utils/downloadCleanupManager.js
@@ -1,0 +1,68 @@
+/**
+ * 下载内存管理器
+ * 使用 LRU 缓存防止内存无限增长
+ * 下载过程中自动清理，下载完成后保留缓存（页面刷新后自然清除）
+ */
+
+export const downloadCleanupManager = {
+  // 保留最近完成的歌曲数量（超过此数量时自动清理最旧的）
+  MAX_PENDING_ITEMS: 16,
+
+  // 存储已完成的下载：{ songItem, blobUrl }
+  pendingCleanup: [],
+
+  /**
+   * 添加完成的下载到队列
+   * 超过限制时自动清理最旧的项
+   * @param {Object} songItem - 歌曲对象
+   * @param {string} blobUrl - Blob URL
+   */
+  addPendingCleanup: function(songItem, blobUrl) {
+    this.pendingCleanup.push({ songItem, blobUrl });
+    // 如果超过最大数量，清理最旧的项目以防止内存溢出
+    while (this.pendingCleanup.length > this.MAX_PENDING_ITEMS) {
+      const oldest = this.pendingCleanup.shift();
+      this.cleanupItem(oldest);
+    }
+  },
+
+  /**
+   * 清理单个项目的内存资源
+   * @param {Object} item - { songItem, blobUrl }
+   */
+  cleanupItem: function(item) {
+    if (!item) return;
+
+    // 释放 Blob URL
+    if (item.blobUrl) {
+      try {
+        URL.revokeObjectURL(item.blobUrl);
+      } catch (e) {
+        // 忽略释放失败的错误
+      }
+    }
+
+    // 清理歌曲下载数据
+    if (item.songItem && item.songItem.download) {
+      item.songItem.download.musicFile = null;
+      item.songItem.download.coverData = null;
+      item.songItem.download.lyricText = null;
+    }
+
+    // 清理专辑详情缓存引用
+    if (item.songItem) {
+      item.songItem.albumDetail = null;
+    }
+  },
+
+  /**
+   * 下载全部完成时调用
+   * 注意：不清理缓存，让页面刷新后自然清除
+   * 这样可以避免文件写入磁盘时删除 Blob URL 导致下载失败
+   */
+  cleanupAll: function() {
+    // 不执行任何清理操作
+    // 缓存会在页面刷新后自动清除
+    // 下载过程中已通过 addPendingCleanup 中的 LRU 机制防止内存无限增长
+  }
+};


### PR DESCRIPTION
## 功能描述

解决批量下载大量歌曲（1000+）时出现的内存泄漏问题。实现了一个轻量级的 LRU（最近最少使用）缓存清理系统，防止长时间下载导致的内存无限增长。

## 问题背景

- 批量下载大量歌曲时，内存占用不断增加，最终导致浏览器卡顿或崩溃
- 下载完成后缓存得不到及时释放，占用过多内存
- 需要找到清理时机与稳定性的平衡点

## 解决方案

### 1. 新增内存管理模块
- **文件**: `src/utils/downloadCleanupManager.js`
- **功能**: LRU 缓存管理，自动清理超出限制的最旧项
- **限额**: 保留最近 16 项已完成的下载

### 2. 集成到批量下载流程
- **文件**: `src/components/batchDownloadSongs.js`
- **改动**: 每次下载完成时调用 `addPendingCleanup()`
- **效果**: 下载过程中自动维护内存占用

### 3. 修复导入路径
- **文件**: `src/playlist/playlistDetail.js`
- **修复**: `SongsDownUpLoad` → `songsDownUpLoad`（Linux 大小写敏感）

## 清理策略详解
下载过程中 (1-16 项) 下载过程中 (>16 项) 下载完成
保留全部缓存 → LRU 自动清理 → 保留缓存
↓
用户刷新页面后清除

| 场景 | 行为 | 原因 |
|------|------|------|
| 单首下载 | 立即保存，无延迟 | 直接触发 LRU |
| 批量下载 | 保留 16 项，超出自动清理 | 防止内存溢出 |
| 下载完成 | 不主动清理 | 避免清理过快导致写入失败 |
| 页面刷新 | 自动清除所有缓存 | 利用页面生命周期 |

## 测试结果

✅ 支持一次性下载 1000+ 首歌曲  
✅ 内存占用保持在可控水平（最多 16 个文件的缓存）  
✅ 下载稳定性不受影响  
✅ 用户无需手动清理，刷新后自动清除  
